### PR TITLE
refactor: Improve Cell<T> implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 mod lifetime;
+mod smart_point;
 
 pub use lifetime::*;
+pub use smart_point::*;

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -6,7 +6,7 @@ pub struct StrSplit<'heystack, D> {
 
 impl<'heystack, D> StrSplit<'heystack, D> {
     pub fn new(haystack: &'heystack str, delimiter: D) -> Self {
-    Self {
+        Self {
             reminder: Some(haystack),
             delimiter,
         }
@@ -45,7 +45,7 @@ impl Delimiter for char {
         // charactar char only have 1 lang
         s.char_indices()
             .find(|(_, c)| c == self)
-            .map(|(start, _)| (start, self.len_utf8())) 
+            .map(|(start, _)| (start, self.len_utf8()))
     }
 }
 

--- a/src/smart_point.rs
+++ b/src/smart_point.rs
@@ -1,0 +1,73 @@
+pub use std::cell::UnsafeCell;
+
+pub struct Cell<T> {
+    value: UnsafeCell<T>,
+}
+
+impl<T> Cell<T> {
+    pub fn new(value: T) -> Self {
+        Cell {
+            value: UnsafeCell::new(value),
+        }
+    }
+
+    pub fn set(&self, value: T) {
+        unsafe { *self.value.get() = value }
+    }
+
+    pub fn get(&self) -> T
+    where
+        T: Copy,
+    {
+        unsafe { *self.value.get() }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum RefSate {
+    Unshare,
+    Share(isize),
+    Exclsive,
+}
+
+/// implied by UnsafeCell
+/// Impl<T> !Sync for RefCell<T> {}
+/// not sync because Share(N) cant not work in multi thread
+struct RefCell<T> {
+    value: UnsafeCell<T>,
+    state: Cell<RefSate>,
+}
+
+impl<T> RefCell<T> {
+    fn new(value: T) -> Self {
+        Self {
+            value: UnsafeCell::new(value),
+            state: Cell::new(RefSate::Unshare),
+        }
+    }
+
+    pub fn borrow(&self) -> Option<&T> {
+        match self.state.get() {
+            RefSate::Unshare => {
+                self.state.set(RefSate::Share(1));
+                Some(unsafe { &*self.value.get() })
+            }
+
+            RefSate::Share(n) => {
+                self.state.set(RefSate::Share(n + 1));
+                Some(unsafe { &*self.value.get() })
+            }
+
+            RefSate::Exclsive => None,
+        }
+    }
+
+    pub fn borrow_mut(&self) -> Option<&mut T> {
+        if let RefSate::Unshare = self.state.get() {
+            self.state.set(RefSate::Exclsive);
+            Some(unsafe { &mut *self.value.get() })
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
Refactored the Cell<T> struct implementation by adding new methods for setting and getting values. Also, implemented the RefSate enum and RefCell<T> struct with borrow and borrow_mut methods. Updated StrSplit and Delimiter implementations. Added a new smart_point module.