### PR TITLE
refactor: Refactored code to use Arc, Condvar, Mutex in channel module

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,61 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Condvar, Mutex},
+};
+
+pub struct Inner<T> {
+    queue: Mutex<VecDeque<T>>,
+    available: Condvar,
+}
+
+// we need Arc, so Sender and Reciver have same memory they can communicate
+#[derive(Clone)]
+pub struct Sender<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> Sender<T> {
+    fn send(&self, t: T) {
+        let mut queue = self.inner.queue.lock().unwrap();
+        queue.push_back(t);
+        drop(queue);
+        self.inner.available.notify_one();
+    }
+}
+
+pub struct Reciver<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> Reciver<T> {
+
+    fn recv(&mut self) -> T {
+        let mut queue = self.inner.queue.lock().unwrap();
+        loop {
+            match queue.pop_front() {
+                Some(t) => return t,
+                None => {
+                    queue = self.inner.available.wait(queue).unwrap();
+                }
+            }
+        }
+    }
+
+}
+
+pub fn channel<T>() -> (Sender<T>, Reciver<T>) {
+    let inner = Inner {
+        queue: Mutex::default(),
+        available: Condvar::new(),
+    };
+
+    let inner = Arc::new(inner);
+    (
+        Sender {
+            inner: inner.clone(),
+        },
+        Reciver {
+            inner: inner.clone(),
+        },
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod channel;
 mod lifetime;
 mod rc;
 mod smart_point;

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,6 +1,6 @@
+use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ops::Deref;
-use std::cell::Cell;
 use std::ptr::NonNull;
 
 struct RcInner<T> {
@@ -12,7 +12,7 @@ struct RcInner<T> {
 // 那我们如何之后一个 Rc对象被 clone被引用了多少次呢
 struct Rc<T> {
     inner: NonNull<RcInner<T>>,
-    _marker: PhantomData<RcInner<T>>
+    _marker: PhantomData<RcInner<T>>,
 }
 
 impl<T> Rc<T> {
@@ -43,7 +43,7 @@ impl<T> Deref for Rc<T> {
     fn deref(&self) -> &Self::Target {
         // SAFETY: inner is Box that only deallocated when the last Rc is gone
         // we have an Rc, therefore that Box has not be deallocated It's fine to Derf
-        &unsafe { self.inner.as_ref()}.value
+        &unsafe { self.inner.as_ref() }.value
     }
 }
 
@@ -52,7 +52,10 @@ impl<T> Clone for Rc<T> {
         let inner = unsafe { self.inner.as_ref() };
         let c = inner.refconter.get();
         inner.refconter.set(c + 1);
-        Rc { inner: self.inner, _marker: PhantomData }
+        Rc {
+            inner: self.inner,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -62,7 +65,7 @@ impl<T> Drop for Rc<T> {
         let c = inner.refconter.get();
         if c == 1 {
             // SAFETY: we are the only Rc left, so we are being droped
-            // there for after us, there will be no Rc's and no reference to T 
+            // there for after us, there will be no Rc's and no reference to T
             let _ = unsafe { Box::from_raw(self.inner.as_ptr()) };
         } else {
             // there are other Rc's left, so we just decrement the refcount


### PR DESCRIPTION
- Changed the implementation of the channel module to use Arc, Condvar, and Mutex for better thread safety and communication between Sender and Receiver.
- Reorganized the code to utilize Arc pointers, Condvar for signaling, and Mutex for thread synchronization.
- Updated the Sender and Receiver structs to use Arc<Inner<T>> for shared memory communication.
- Implemented send and receive methods in Sender and Receiver structs respectively for thread-safe communication.