### PR TITLE
refactor: Change inner queue type to VecDeque and optimize Sender and Reciever structs

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,61 +1,119 @@
 use std::{
-    collections::VecDeque,
-    sync::{Arc, Condvar, Mutex},
+    collections::VecDeque, path::Iter, sync::{Arc, Condvar, Mutex}
 };
 
-pub struct Inner<T> {
-    queue: Mutex<VecDeque<T>>,
+struct Inner<T> {
+    queue: VecDeque<T>,
+    senders: usize,
+}
+
+pub struct Shared<T> {
+    inner: Mutex<Inner<T>>,
     available: Condvar,
 }
 
 // we need Arc, so Sender and Reciver have same memory they can communicate
-#[derive(Clone)]
 pub struct Sender<T> {
-    inner: Arc<Inner<T>>,
+    shared: Arc<Shared<T>>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        let mut innner = self.shared.inner.lock().unwrap();
+        innner.senders += 1;
+        drop(innner);
+        Self {    
+            shared: Arc::clone(&self.shared)
+        }
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        eprintln!("Drop happen");
+        let mut inner = self.shared.inner.lock().unwrap();
+        inner.senders -= 1;
+        let was_last = inner.senders == 0;
+        drop(inner);
+        if was_last {
+            self.shared.available.notify_all();
+        }
+    }
 }
 
 impl<T> Sender<T> {
     fn send(&self, t: T) {
-        let mut queue = self.inner.queue.lock().unwrap();
-        queue.push_back(t);
-        drop(queue);
-        self.inner.available.notify_one();
+        let mut inner = self.shared.inner.lock().unwrap();
+        inner.queue.push_back(t);
+        drop(inner);
+        self.shared.available.notify_one();
     }
 }
 
 pub struct Reciver<T> {
-    inner: Arc<Inner<T>>,
+    shared: Arc<Shared<T>>,
 }
 
-impl<T> Reciver<T> {
+impl<T> Iterator for Reciver<T> {
+    type Item = T;
 
-    fn recv(&mut self) -> T {
-        let mut queue = self.inner.queue.lock().unwrap();
+    fn next(&mut self) -> Option<Self::Item> {
+        self.recv()
+    }
+}
+
+
+impl<T> Reciver<T> {
+    fn recv(&mut self) -> Option<T> {
+        let mut inner = self.shared.inner.lock().unwrap();
         loop {
-            match queue.pop_front() {
-                Some(t) => return t,
+            match inner.queue.pop_front() {
+                Some(t) => return Some(t),
+                None if inner.senders == 0 => return None,
                 None => {
-                    queue = self.inner.available.wait(queue).unwrap();
+                    inner = self.shared.available.wait(inner).unwrap();
                 }
             }
         }
     }
-
 }
 
 pub fn channel<T>() -> (Sender<T>, Reciver<T>) {
-    let inner = Inner {
-        queue: Mutex::default(),
+    let shared = Shared {
         available: Condvar::new(),
+        inner: Mutex::new(Inner {
+            queue: VecDeque::new(),
+            senders: 1,
+        }),
     };
 
-    let inner = Arc::new(inner);
+    let shared = Arc::new(shared);
     (
         Sender {
-            inner: inner.clone(),
+            shared: shared.clone(),
         },
         Reciver {
-            inner: inner.clone(),
+            shared: shared.clone(),
         },
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn send_recv() {
+        let (tx, mut rx) = channel();
+        tx.send(42);
+        assert_eq!(rx.recv(), Some(42));
+    }
+
+    #[test]
+    fn remove_tx() {
+        let (tx, mut rx) = channel::<i32>();
+        drop(tx);
+        // let _ = tx;
+        assert_eq!(rx.recv(), None);
+    }
 }


### PR DESCRIPTION
The changes include switching the inner queue type from being wrapped in a Mutex to directly using VecDeque. The Sender struct has been updated to have a shared Arc of Shared instead of Inner. The Reciever struct is also updated to use a shared Arc of Shared. Additionally, a new implementation of Drop for Sender has been added to handle tracking and notifying when all senders are dropped. The recv method in Reciever has been changed to return an Option<T> instead of T. Lastly, new test functions have been added for send and recv functionality and handling of dropped senders.